### PR TITLE
Use ADD instead of Curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Download Packer
 
-# renovate: datasource=repology depName=debian_12/curl versioning=deb
-ENV CURL_VERSION=7.88.1-10+deb12u6
 # renovate: datasource=github-releases depName=hashicorp/packer extractVersion=^v(?<version>.*)$
 ENV PACKER_VERSION=1.11.2
 # renovate: datasource=repology depName=debian_12/unzip versioning=deb
 ENV UNZIP_VERSION=6.0
 
+# Download Packer
+ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip /tmp/packer.zip
 RUN apt-get update -y && \
-  # Install necessary dependencies
-  apt-get install -y --no-install-recommends curl=${CURL_VERSION} unzip=${UNZIP_VERSION}-28 && \
-  # Download Packer
-  curl -o /tmp/packer.zip https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
+  apt-get install -y --no-install-recommends unzip=${UNZIP_VERSION}-28 && \
   unzip /tmp/packer.zip -d /tmp && \
   rm /tmp/packer.zip
 


### PR DESCRIPTION
Use ADD instead of Curl to download Packer.

Fixes https://rules.sonarsource.com/docker/RSPEC-7026/